### PR TITLE
add -Wno-write-strings to UNITTEST_CXXFLAGS

### DIFF
--- a/make/2_build.Makefile
+++ b/make/2_build.Makefile
@@ -9,7 +9,7 @@ ifneq ($(OS),Windows_NT)
 UNITTEST_LIBS ?= -ldl
 endif
 
-UNITTEST_CXXFLAGS += -std=gnu++14 -Werror -Wall -ggdb -DDEBUG -DUNITTEST --coverage
+UNITTEST_CXXFLAGS += -std=gnu++14 -Werror -Wall -ggdb -Wno-write-strings -DDEBUG -DUNITTEST --coverage
 UNITTEST_LDFLAGS += --coverage
 __UNITTEST_INCLUDES = -I$(VOODOO_MIRROR_TREE) $(UNITTEST_INCLUDES)
 #NOTE: VOODOO_MIRROR_TREE must come first in include order, or interception magia will not work


### PR DESCRIPTION
Recently a new kernelight module (upgrader) was added. It defines a
string module param that has a default value. The problem is that
it can't be compile as C++.
Why?
C and C++ differ in the type of the string literal. In C the type
is array of char and in C++ it is constant array of char.
For backwards compatibility with C the language, C++ still allows
assigning a string literal to a char* and gives a warning about
this conversion being deprecated.
But we also use the Werror flag, meaning that each warning is
treated as an error.
So we need to supress this warning becauese it fails our unittest
compilation.

Related PRs: https://github.com/LightBitsLabs/kernelight/pull/1933

Issues: LBM1-4334, LBM1-4389