### PR TITLE
unitest build: enforce serial run on most.Makefile

### DIFF
--- a/make/integrations/most.Makefile
+++ b/make/integrations/most.Makefile
@@ -4,6 +4,8 @@ else
   Q = @
 endif
 
+.NOTPARALLEL:
+
 clean_unittest:
 	rm -fr build_unittest coverage
 


### PR DESCRIPTION
Some jenkins build and (suspectedly) other source might run targets on this make file with -j option.
This is unwanted, since build should be run before the running of tests.
Here we add .NOTPARALLEL to run all targets serially, even if the ‘-j’ option is given.