### PR TITLE
Voodoo-Mock: set python2.7 as default

### DIFF
--- a/make/1_generate.Makefile
+++ b/make/1_generate.Makefile
@@ -9,10 +9,10 @@ VOODOO_EXTERNALS_FLAGS ?=
 VOODOO_INCLUDES ?= --includePath=.
 
 __VOODOO_ENVIRONMENT = PYTHONPATH=$(VOODOO_ROOT_DIR)/voodoo LD_LIBRARY_PATH=$(VOODOO_ROOT_DIR)/voodoo:$(LD_LIBRARY_PATH)
-__VOODOO_MULTI_EXECUTABLE = $(__VOODOO_ENVIRONMENT) python '$(VOODOO_ROOT_DIR)/voodoo/multi.py'
+__VOODOO_MULTI_EXECUTABLE = $(__VOODOO_ENVIRONMENT) $(PYTHON2_EXECUTABLE) '$(VOODOO_ROOT_DIR)/voodoo/multi.py'
 __VOODOO_MULTI_INPUT = $(addprefix --input=,$(VOODOO_SCAN_HEADERS_ROOTS))
 __VOODOO_MULTI_EXCLUDES = $(addprefix --exclude=,$(VOODOO_MULTI_EXCLUDES) '\b$(UNITTEST_BUILD_DIRECTORY)\b')
-__VOODOO_SINGLE_EXECUTABLE = $(__VOODOO_ENVIRONMENT) python '$(VOODOO_ROOT_DIR)/voodoo/single.py'
+__VOODOO_SINGLE_EXECUTABLE = $(__VOODOO_ENVIRONMENT) $(PYTHON2_EXECUTABLE) '$(VOODOO_ROOT_DIR)/voodoo/single.py'
 __VOODOO_FLAGS = $(VOODOO_FLAGS) --voodooDB=$(UNITTEST_BUILD_DIRECTORY)/voodooDB.tmp $(VOODOO_INCLUDES)
 
 $(if $(filter-out %.cxx,$(CXXTEST_GENERATED)),\
@@ -49,4 +49,4 @@ $(VOODOO_MIRROR_TREE)/%.h:
 $(UNITTEST_BUILD_DIRECTORY)/%.cxx:
 	-$(Q)mkdir --parents $(@D)
 	@echo 'CXXTSTGN' $@
-	$(Q)python $(VOODOO_ROOT_DIR)/cxxtest/simplecxxtestgen.py --output=$@ --input=$< 
+	$(Q)$(PYTHON2_EXECUTABLE) $(VOODOO_ROOT_DIR)/cxxtest/simplecxxtestgen.py --output=$@ --input=$<

--- a/make/3_run.Makefile
+++ b/make/3_run.Makefile
@@ -8,4 +8,4 @@ PYTEST_TEST_FILES = $(shell find $(PYTEST_FIND_PATTERN) $(__REMOVE_DOT_SLASH_PRE
 runAllTests:
 	$(Q)echo "Running all tests"
 	$(Q)rm -fr .coverage*
-	$(Q)python $(VOODOO_ROOT_DIR)/pytest/pytestharness.py $(PYTESTHARNESS_FLAGS) $(CXXTEST_BINARIES) $(PYTEST_TEST_FILES)
+	$(Q)$(PYTHON2_EXECUTABLE) $(VOODOO_ROOT_DIR)/pytest/pytestharness.py $(PYTESTHARNESS_FLAGS) $(CXXTEST_BINARIES) $(PYTEST_TEST_FILES)

--- a/make/4_optional_enforce_cpp_coverage.Makefile
+++ b/make/4_optional_enforce_cpp_coverage.Makefile
@@ -5,4 +5,4 @@ include $(VOODOO_ROOT_DIR)/make/common.Makefile
 ENFORCE_COVERAGE_CPP_SOURCE_FILES = $(shell find $(ENFORCE_COVERAGE_FIND_PATTERN_CPP) $(__REMOVE_DOT_SLASH_PREFIX))
 
 runEnforcement:
-	$(Q)python $(VOODOO_ROOT_DIR)/make/enforce_cpp_coverage.py $(CXXTEST_BINARIES) --enforceOn $(ENFORCE_COVERAGE_CPP_SOURCE_FILES)
+	$(Q)$(PYTHON2_EXECUTABLE) $(VOODOO_ROOT_DIR)/make/enforce_cpp_coverage.py $(CXXTEST_BINARIES) --enforceOn $(ENFORCE_COVERAGE_CPP_SOURCE_FILES)

--- a/make/common.Makefile
+++ b/make/common.Makefile
@@ -1,3 +1,4 @@
+PYTHON2_EXECUTABLE ?= python2.7
 UNITTEST_BUILD_DIRECTORY ?= build_unittest
 CXXTEST_FIND_ROOT ?=
 CXXTEST_FIND_PATTERN ?= $(CXXTEST_FIND_ROOT) -name 'test_*.h' -or -name 'Test_*.h'

--- a/make/common.sh
+++ b/make/common.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+export PYTHON2_EXECUTABLE=python2.7

--- a/make/runsingletest.sh
+++ b/make/runsingletest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 SUITE=$1
 REGEX_OR_LINE_NUMBER=$2
-
+source common.sh
 function isPython {
     echo $SUITE | grep '\.py$' > /dev/null
 }
@@ -11,13 +11,13 @@ function isCxxTest {
 
 if isPython $SUITE; then
     TEST_NAME=`python $VOODOO_ROOT_DIR/pytest/findtestname.py $SUITE $REGEX_OR_LINE_NUMBER`
-	python $VOODOO_ROOT_DIR/pytest/pytestrunner.py --verbose --singleTest=$TEST_NAME $SUITE
+	$PYTHON2_EXECUTABLE $VOODOO_ROOT_DIR/pytest/pytestrunner.py --verbose --singleTest=$TEST_NAME $SUITE
 else
     if [ ! isCxxTest ]; then
         echo "$SUITE was not recognized as niether python test suite or CxxTest suite files"
         exit 1
     fi
-    TEST_NAME=`python $VOODOO_ROOT_DIR/pytest/findtestname.py $SUITE $REGEX_OR_LINE_NUMBER`
+    TEST_NAME=`$PYTHON2_EXECUTABLE $VOODOO_ROOT_DIR/pytest/findtestname.py $SUITE $REGEX_OR_LINE_NUMBER`
     NO_EXT=`echo $SUITE | sed 's@\.[hH].\?.\?$@@'`
     NO_EXT_UNDERSCORE=`echo $NO_EXT | sed 's@/@_@g'`
     BIN=build_unittest/${NO_EXT_UNDERSCORE}.bin

--- a/make/runsingletestsuite.sh
+++ b/make/runsingletestsuite.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 SUITE=$1
+source common.sh
 
 function isPython {
     echo $SUITE | grep '\.py$' > /dev/null
@@ -9,7 +10,7 @@ function isCxxTest {
 }
 
 if isPython $SUITE; then
-	python $VOODOO_ROOT_DIR/pytest/pytestrunner.py --verbose $SUITE
+	$PYTHON2_EXECUTABLE $VOODOO_ROOT_DIR/pytest/pytestrunner.py --verbose $SUITE
 else
     if [ ! isCxxTest ]; then
         echo "$SUITE was not recognized as niether python test suite or CxxTest suite files"


### PR DESCRIPTION
all python code in Voodoo-Mock lib is written with python2.7
It has to be set manually now as dockerize image default python version was upgraded to python3.
related pr in common: https://github.com/LightBitsLabs/common/pull/3891

Tests:
all Voodoo mock tests in [related common pr check ](http://jenkins:8080/job/common_duros_pr_validation/4086)have passed:
```
18:46:36 make -f /storage/jenkins_slaves/allocator_pr_1/lb/lb_workspace_common_duros_pr/repo_ws_duros/Voodoo-Mock/make/3_run.Makefile
18:46:36 make[2]: Entering directory '/storage/jenkins_slaves/allocator_pr_1/lb/lb_workspace_common_duros_pr/repo_ws_duros/kernelight'
18:46:36 Running all tests
18:46:36 Running 21 fresh suites (total 21)
18:46:36 .....................
18:48:56 OK!
18:48:56 CPP tests: 248 (0 skipped)
18:48:56 Python tests: 0
18:48:56 Total: 248 tests
```