### PR TITLE
Compile test with C++20.

### DIFF
--- a/cxxtest/cxxtest/ValueTraits.cpp
+++ b/cxxtest/cxxtest/ValueTraits.cpp
@@ -97,7 +97,7 @@ namespace CxxTest
     unsigned ValueTraits<const double>::requiredDigitsOnLeft( double t )
     {
         unsigned digits = 1;
-        for ( t = (t < 0.0) ? -t : t; t > 1.0; t /= BASE )
+        for ( t = (t < 0.0) ? -t : t; t > 1.0; t /= static_cast<double>(BASE)  )
             ++ digits;
         return digits;
     }
@@ -127,7 +127,7 @@ namespace CxxTest
         s = doubleToString( t, s );
         s = copyString( s, "." );
         for ( unsigned i = 0; i < DIGITS_ON_RIGHT; ++ i )
-            s = numberToString( (unsigned)(t *= BASE) % BASE, s );
+			s = numberToString( (unsigned)(t *= static_cast<double>(BASE)) % BASE, s );
     }
 
     char *ValueTraits<const double>::doubleToString( double t, char *s, unsigned skip, unsigned max )

--- a/make/2_build.Makefile
+++ b/make/2_build.Makefile
@@ -9,7 +9,7 @@ ifneq ($(OS),Windows_NT)
 UNITTEST_LIBS ?= -ldl
 endif
 
-UNITTEST_CXXFLAGS += -std=gnu++14 -Werror -Wall -ggdb -DDEBUG -DUNITTEST --coverage -Wno-terminate -fsanitize=address
+UNITTEST_CXXFLAGS += -std=gnu++20 -Werror -Wall -ggdb -DDEBUG -DUNITTEST --coverage -Wno-terminate -fsanitize=address
 UNITTEST_LDFLAGS += --coverage -fsanitize=address
 __UNITTEST_INCLUDES = -I$(VOODOO_MIRROR_TREE) $(UNITTEST_INCLUDES)
 #NOTE: VOODOO_MIRROR_TREE must come first in include order, or interception magia will not work


### PR DESCRIPTION
This change required for kernelight upgrade toolchain to gcc14.

Issue: LBM1-36473